### PR TITLE
Fix expo-router entry export

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,1 +1,1 @@
-import "expo-router/entry";
+export { default } from "expo-router/entry";


### PR DESCRIPTION
## Summary
- correct Expo entry so default export is a component

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6858252e036483288655f93fa359662f