### PR TITLE
Fix Base44 client init crash

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -46,7 +46,11 @@ function HomeScreen() {
  
   useEffect(() => {
     const client = getClient();
-    if (client && client.auth && typeof client.auth.useSession === 'function') {
+    if (!client) {
+      console.warn('⚠️ Base44 client failed to initialize');
+      return;
+    }
+    if (client.auth && typeof client.auth.useSession === 'function') {
       client.auth.useSession();
     } else {
       console.warn('⚠️ Base44 client or auth module not available');

--- a/lib/api/base44Client.js
+++ b/lib/api/base44Client.js
@@ -1,13 +1,24 @@
-import { createClient } from '@base44/sdk';
+import * as Base44 from '@base44/sdk';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 let client;
 
 export function getClient() {
   console.log('Base44 client initialized:', !!client);
-  // Check if the client is already created
   if (!client) {
-    client = createClient({
+    const create =
+      typeof Base44.createClient === 'function'
+        ? Base44.createClient
+        : typeof Base44.default === 'function'
+          ? Base44.default
+          : Base44.default?.createClient;
+
+    if (typeof create !== 'function') {
+      console.warn('⚠️ Base44 createClient is unavailable');
+      return undefined;
+    }
+
+    client = create({
       appId: '683f20362852a84143aef3f6',
       requiresAuth: true,
       getToken: async () => {


### PR DESCRIPTION
## Summary
- ensure `getClient` resolves createClient correctly
- guard against missing client/auth when calling `useSession`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aa239d1b08328b6430344c3fb82a8